### PR TITLE
[namespaces] applyAuto will remember ns from now on

### DIFF
--- a/async-utils.js
+++ b/async-utils.js
@@ -73,7 +73,7 @@ function _nullNamespace() {
 
 
 function _retrieveActiveNamespace() {
-    var ns = process.namespaces;
+    var ns = process.namespaces || {};
     var active;
 
     // Tries to retrieves active namespace


### PR DESCRIPTION
@tinchogob 

Estuvimos viendo con @alarre que ```applyAuto``` no conserva el contexto.  Con este fix se solucionaría.

Lo ideal sería no poner este cambio en master sino en un branch *release/0.0.4_rc1*, pero no estoy pudiendo crear el branch. Por eso al PR contra master.