### PR TITLE
Lodash version update

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Node complementary utils for Caolan async's module",
   "main": "async-utils.js",
   "dependencies": {
-    "lodash": "4.17.5"
+    "lodash": "4.17.11"
   },
   "devDependencies": {
     "mocha": "*",


### PR DESCRIPTION
Debido a una [vulnerabilidad](https://nvd.nist.gov/vuln/detail/CVE-2018-16487) que nos reportó Opportunitties