### PR TITLE
Update lodash version

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Node complementary utils for Caolan async's module",
   "main": "async-utils.js",
   "dependencies": {
-    "lodash": "4.17.11"
+    "lodash": "4.17.15"
   },
   "devDependencies": {
     "mocha": "*",


### PR DESCRIPTION
Debido a [vulnerabilidad](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-10744) reportada por Opportunities.